### PR TITLE
Use correct constant in Argon2::default.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ impl Argon2 {
     /// Returns an `Argon2` set to default input parameters. See below for a
     /// description of these parameters.
     pub fn default(v: Variant) -> Argon2 {
-        Argon2::new(defaults::PASSES, defaults::LANES, defaults::LANES, v)
+        Argon2::new(defaults::PASSES, defaults::LANES, defaults::KIB, v)
             .ok()
             .unwrap()
     }


### PR DESCRIPTION
`Argon2::default` has a copy/paste error in it that makes it panic. The third argument is supposed to be `defaults::KIB`.