### PR TITLE
Less restrictive convenience hashing functions

### DIFF
--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -314,7 +314,9 @@ impl Argon2 {
 /// Convenience wrapper around Argon2i for the majority of use cases where only
 /// a password and salt are supplied. Note that a salt between 8 and 2^32 - 1
 /// bytes must be provided.
-pub fn argon2i_simple<T: AsRef<[u8]>>(password: &T, salt: &T) -> [u8; defaults::LENGTH] {
+pub fn argon2i_simple<P, S>(password: &P, salt: &S) -> [u8; defaults::LENGTH]
+    where P: AsRef<[u8]> + ?Sized, S: AsRef<[u8]> + ?Sized
+{
     let mut out = [0; defaults::LENGTH];
     let a2 = Argon2::default(Variant::Argon2i);
     a2.hash(&mut out, password.as_ref(), salt.as_ref(), &[], &[]);
@@ -324,7 +326,9 @@ pub fn argon2i_simple<T: AsRef<[u8]>>(password: &T, salt: &T) -> [u8; defaults::
 /// Convenience wrapper around Argon2d for the majority of use cases where only
 /// a password and salt are supplied. Note that a salt between 8 and 2^32 - 1
 /// bytes must be provided.
-pub fn argon2d_simple<T: AsRef<[u8]>>(password: &T, salt: &T) -> [u8; defaults::LENGTH] {
+pub fn argon2d_simple<P, S>(password: &P, salt: &S) -> [u8; defaults::LENGTH]
+    where P: AsRef<[u8]> + ?Sized, S: AsRef<[u8]> + ?Sized
+{
     let mut out = [0; defaults::LENGTH];
     let a2 = Argon2::default(Variant::Argon2d);
     a2.hash(&mut out, password.as_ref(), salt.as_ref(), &[], &[]);

--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -314,20 +314,20 @@ impl Argon2 {
 /// Convenience wrapper around Argon2i for the majority of use cases where only
 /// a password and salt are supplied. Note that a salt between 8 and 2^32 - 1
 /// bytes must be provided.
-pub fn argon2i_simple(password: &str, salt: &str) -> [u8; defaults::LENGTH] {
+pub fn argon2i_simple<T: AsRef<[u8]>>(password: &T, salt: &T) -> [u8; defaults::LENGTH] {
     let mut out = [0; defaults::LENGTH];
     let a2 = Argon2::default(Variant::Argon2i);
-    a2.hash(&mut out, password.as_bytes(), salt.as_bytes(), &[], &[]);
+    a2.hash(&mut out, password.as_ref(), salt.as_ref(), &[], &[]);
     out
 }
 
 /// Convenience wrapper around Argon2d for the majority of use cases where only
 /// a password and salt are supplied. Note that a salt between 8 and 2^32 - 1
 /// bytes must be provided.
-pub fn argon2d_simple(password: &str, salt: &str) -> [u8; defaults::LENGTH] {
+pub fn argon2d_simple<T: AsRef<[u8]>>(password: &T, salt: &T) -> [u8; defaults::LENGTH] {
     let mut out = [0; defaults::LENGTH];
     let a2 = Argon2::default(Variant::Argon2d);
-    a2.hash(&mut out, password.as_bytes(), salt.as_bytes(), &[], &[]);
+    a2.hash(&mut out, password.as_ref(), salt.as_ref(), &[], &[]);
     out
 }
 


### PR DESCRIPTION
`Argon2::hash()` accepts `&[u8]` as password and salt.
`argon2d_simple()` and `argon2i_simple()` accept `&str` as password and salt
and convert them to `&[u8]`.

Instead of the conversion, `argon2d_simple()` and `argon2i_simple()` could accept
types that implement `AsRef<[u8]>` or `&[u8]` directly.