### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/argon2.rs
+++ b/src/argon2.rs
@@ -400,7 +400,7 @@ impl Gen2i {
         let mut rv = Gen2i { arg: zero(), pseudos: zero(), idx: start_at };
         let args = [(pass, lane), (slice, totblocks),
                     (totpasses, Variant::Argon2i as u32)];
-        for (k, &(lo, hi)) in rv.arg.iter_mut().zip(args.into_iter()) {
+        for (k, &(lo, hi)) in rv.arg.iter_mut().zip(args.iter()) {
             *k = u64x2(lo as u64, hi as u64);
         }
         rv.more();


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.